### PR TITLE
Add `bundle` npm script to use native Composer archive command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 /vendor
+/bundle
 /composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,32 @@
 {
-	"name"        : "justintadlock/mythic",
-        "type"        : "wordpress-theme",
-	"description" : "A WordPress starter theme.",
-	"keywords"    : ["wordpress"],
-	"homepage"    : "https://themehybrid.com/themes/mythic",
-	"license"     : "GPL-2.0-or-later",
-	"authors"     : [
+	"name": "justintadlock/mythic",
+    "type": "wordpress-theme",
+	"description": "A WordPress starter theme.",
+	"keywords": ["wordpress"],
+	"homepage": "https://themehybrid.com/themes/mythic",
+	"license": "GPL-2.0-or-later",
+	"authors": [
 		{
-			"name"    : "Justin Tadlock",
-			"email"   : "justintadlock@gmail.com",
+			"name": "Justin Tadlock",
+			"email": "justintadlock@gmail.com",
 			"homepage": "http://justintadlock.com"
 		}
 	],
-        "require": {
-                "php" : ">=5.6",
-                "composer/installers" : "~1.0",
-                "justintadlock/hybrid-core" : "5.0.x-dev"
-        },
+	"require": {
+		"php": ">=5.6",
+		"composer/installers": "~1.0",
+		"justintadlock/hybrid-core": "5.0.x-dev"
+	},
 	"require-dev": {
 		"wp-coding-standards/wpcs": "^1.0.0",
 		"wimg/php-compatibility": "^8.2"
-	}
+	},
+	"archive": {
+        "exclude": [
+			"themeclaim.json",
+			"composer.json",
+			"!vendor/justintadlock",
+			"!vendor/autoload.php"
+		]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "justintadlock/mythic",
-    "type": "wordpress-theme",
+	"type": "wordpress-theme",
 	"description": "A WordPress starter theme.",
 	"keywords": ["wordpress"],
 	"homepage": "https://themehybrid.com/themes/mythic",
@@ -22,11 +22,11 @@
 		"wimg/php-compatibility": "^8.2"
 	},
 	"archive": {
-        "exclude": [
+		"exclude": [
 			"themeclaim.json",
 			"composer.json",
 			"!vendor/justintadlock",
 			"!vendor/autoload.php"
 		]
-    }
+	}
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		"i18n": "npm run i18n:textdomain && npm run i18n:pot",
 		"i18n:textdomain": "npx wpi18n addtextdomain --exclude=vendor,node_modules",
 		"i18n:pot": "npx wpi18n makepot",
-		"rename": "theme-claim"
+		"rename": "theme-claim",
+		"bundle": "composer archive --dir bundle --format=zip"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This should hopefully, at least partly address #32.

To explain, there is a built in `composer archive` command which by default uses the `.gitignore` file of the project on what to ignore. You can however add/exclude other files/folders within the `composer.json` file.

At the moment this automatically generates the archive name (not entirely sure what it uses for this - looks like `name` field plus a number). We could pass in an additional parameter of `--name=namehere` to give it a more specific name if needed.

The only other thing I considered is at the moment I'm allowing specific files/folders within `vendor`. Maybe a better approach would be to chain the `bundle` script with a `composer install --no-dev` command first, then bundle everything? Maybe it should also run production and translate scripts as well?