### PR TITLE
Better export ignores?

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,6 @@
 /.*              export-ignore
 /*.json          export-ignore
 /*.lock          export-ignore
-/*.log           export-ignore
 /*.xml           export-ignore
 /*.xml.dist      export-ignore
 /*.yml           export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,32 +1,29 @@
 # Exclude from release archives.
 
-/.editorconfig        export-ignore
-/.eslintignore        export-ignore
-/.eslintrc            export-ignore
-/.git                 export-ignore
-/.gitattributes       export-ignore
-/.gitignore           export-ignore
-/.phpcs.xml           export-ignore
-/.phpcs.xml.dist      export-ignore
-/.stylelintrc         export-ignore
-/.stylelintignore     export-ignore
-/composer.lock        export-ignore
-/package.json         export-ignore
-/package-lock.json    export-ignore
-/phpcs.xml            export-ignore
-/webpack.mix.js       export-ignore
-/yarn.lock            export-ignore
-/resources/fonts      export-ignore
-/resources/img        export-ignore
-/resources/js         export-ignore
-/resources/scss       export-ignore
-/resources/svg        export-ignore
+/.*              export-ignore
+/*.json          export-ignore
+/*.lock          export-ignore
+/*.log           export-ignore
+/*.xml           export-ignore
+/*.xml.dist      export-ignore
+/*.yml           export-ignore
+/bin/            export-ignore
+/resources/fonts export-ignore
+/resources/img   export-ignore
+/resources/js    export-ignore
+/resources/scss  export-ignore
+/resources/svg   export-ignore
+/tests/          export-ignore
+/webpack.mix.js  export-ignore
 
 # Handle line endings.
 # See https://help.github.com/articles/dealing-with-line-endings/
 
 * text eol=lf
-*.jpg binary
-*.png binary
 *.gif binary
 *.ico binary
+*.jpg binary
+*.png binary
+
+# Don't diff or textually merge source maps
+*.map binary


### PR DESCRIPTION
I have not much experience with this but to me it seem fine. In a WP project you probably won't want to export any dotfiles and json xml yml ... because its all just build configs and stuff the chance that a theme want to export any files like that that also sit it the root folder is pretty slim but I am curious what people think about this. I seen that a lot that people list every single file individually and thought "why?". `.git` is auto ignored, no need to specifically add that AFAIK.

I also saw that there is a mix config for bundling the theme so if that is used the git export may not be important anyway? I never used laravel mix but just based on what I see I actually prefer git export a specific tag to a zip rather then bundling the current state of the directory like that. Maybe I miss something but if its just copying and then zipping files there is no need for yet another tool and config if git-archive has all I need. And funny enough there is a PR that wants to use composer to bundle things. https://github.com/justintadlock/mythic/pull/34. Did not even know it also can do that, yet anther way to bundle. But looks like you are set on the mix bundle config.

`.yml` for CI configs and other stuff
`/bin/` and `/tests/` in case any PHP Unit testing is added (Travis/Gitlab CI or just locally)

Treating .map as binary seen in https://github.com/twbs/bootstrap/blob/v4-dev/.gitattributes