### PR TITLE
Use standaloneSass with BrowserSync

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -109,10 +109,20 @@ var sassConfig = {
 	indentWidth : 1
 };
 
-// Compile SASS/CSS.
-mix.sass( `${devPath}/scss/screen.scss`,             'css', sassConfig )
-   .sass( `${devPath}/scss/editor.scss`,             'css', sassConfig )
-   .sass( `${devPath}/scss/customize-controls.scss`, 'css', sassConfig );
+if ( !process.env.sync ) {
+
+	// Compile SASS/CSS
+	mix.sass( `${devPath}/scss/screen.scss`, 'css', sassConfig )
+	   .sass( `${devPath}/scss/editor.scss`, 'css', sassConfig )
+	   .sass( `${devPath}/scss/customize-controls.scss`, 'css', sassConfig );
+} else {
+
+	// Use fast Sass for Browsersync
+	// @link https://github.com/JeffreyWay/laravel-mix/blob/master/docs/css-preprocessors.md#standalone-sass-builds
+	mix.standaloneSass( `${devPath}/scss/screen.scss`, 'css', sassConfig )
+	   .standaloneSass( `${devPath}/scss/editor.scss`, 'css', sassConfig )
+	   .standaloneSass( `${devPath}/scss/customize-controls.scss`, 'css', sassConfig );
+}
 
 /*
  * Add custom Webpack configuration.


### PR DESCRIPTION
As we by default don't process URLs with Webpack and use a plugin to process and copy images we can take advantage of bypassing Webpack altogether for compiling Sass when running Browsersync with Mix's [standaloneSass](https://github.com/JeffreyWay/laravel-mix/blob/master/docs/css-preprocessors.md#standalone-sass-builds).

It is much faster (when running Browsersync it was 4 times faster for me on a fresh install) and it does not reload the page as is the case when using default loader JeffreyWay/laravel-mix#1053. The only downside is we won't have postCss processing, but only when running the Browsersync command.

Browsersync takes care of watching the files so this won't work with the default `watch` command.